### PR TITLE
Change deploy steps order

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
     - cron: '*/5 * * * *'
 
 jobs:
-  build_and_deploy:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,21 +19,23 @@ jobs:
           ruby-version: 2.6
           bundler-cache: true
 
-      # Build
+      # Install
       - name: Install dependencies
         run: bundle install --deployment
 
-      - name: Build
-        run: bundle exec bin/build
-        env:
-          GOOGLE_SHEETS_API_KEY: ${{ secrets.GOOGLE_SHEETS_API_KEY }}
-          GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
 
       # Test
       - name: Install dependencies
         run: bundle install
       - name: Run tests
         run: bundle exec rspec
+
+      # Build
+      - name: Build
+        run: bundle exec bin/build
+        env:
+          GOOGLE_SHEETS_API_KEY: ${{ secrets.GOOGLE_SHEETS_API_KEY }}
+          GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
 
       # Deploy
       - name: Copying files


### PR DESCRIPTION
## Description

Actuellement, les tests n'ont pas de cleaning et sont lancés après le build dans le workflow de déploiement. En attendant de trouver comment cleaning après la suite de tests, cette PR déplace l'étape des tests avant le build.